### PR TITLE
travis-ci: reflect new best-practice travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ go:
   - "1.11.x"
   - tip
 
-# This is a weird way of telling Travis to use the fast container-based test
-# runner instead of the slow VM-based runner.
-sudo: false
-
 matrix:
   allow_failures:
   - go: tip


### PR DESCRIPTION
Travis-CI has or will shortly make in early December 2018 a number of beneficial
changes to their Linux continuous integration testing infrastructure [0][1].

The benefit for bloomfilter-go is primarily:
* Modest speed improvements from Travis-CI move to Linux infrastructure combined
  into one (virtualized), from two previously (virtualized and container-based).

[0] https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures
[1] https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration